### PR TITLE
Added declaration file for iso3166 library

### DIFF
--- a/iso3166.min.d.ts
+++ b/iso3166.min.d.ts
@@ -12,9 +12,14 @@ interface Country {
   sub: Subdivisions;
 }
 
-export function country(name: string): Country;
-export function subdivision(type:string, name: string): Subdivision;
+export function country(code: string): Country;
+export function subdivision(country:string, code: string): Subdivision;
 
-export const data: Subdivisions;
-export const codes: Subdivisions;
-
+interface CountryMapping {
+  [code: string]: Country;
+}
+export const data: CountryMapping;
+interface CodeMapping {
+  [code: string]: string;
+}
+export const codes: CodeMapping;

--- a/iso3166.min.d.ts
+++ b/iso3166.min.d.ts
@@ -1,0 +1,20 @@
+export as namespace iso3166;
+
+interface Subdivision {
+  type: string;
+  name: string;
+}
+interface Subdivisions {
+  [code: string]: Subdivision;
+}
+interface Country {
+  name: string;
+  sub: Subdivisions;
+}
+
+export function country(name: string): Country;
+export function subdivision(type:string, name: string): Subdivision;
+
+export const data: Subdivisions;
+export const codes: Subdivisions;
+


### PR DESCRIPTION
Adding [declaration file](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) for the library `iso3166` based on the template [`module.d.ts`](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html) taken from the official documentation of TypeScript 